### PR TITLE
Milestone27/add filters to products endpoint

### DIFF
--- a/app/controllers/api/products_controller.rb
+++ b/app/controllers/api/products_controller.rb
@@ -1,6 +1,7 @@
 module Api
   class ProductsController < ApplicationController
     include Search::Handler
+    include Search::ProductFilters
     include AssociateFiles
 
     before_action :valid_session, except: %i[send_email index show]
@@ -14,7 +15,9 @@ module Api
 
     def index
       @custom_list = valid_session_conditions ? Product.readable_by(current_user) : Product.readable
-      render json: { products: paginated_response }, status: :ok
+      list = paginated_response
+      filters = params[:filters].present? ? filters(@list, params[:filters]) : {}
+      render json: { products: list.merge(filters) }, status: :ok
     end
 
     def create

--- a/app/controllers/concerns/search/product.rb
+++ b/app/controllers/concerns/search/product.rb
@@ -13,7 +13,7 @@ module Search
     end
 
     def product_search_params
-      %i[keyword brand project_type specification room_type section item subitem]
+      %i[keyword brand client project_type specification room_type section item subitem]
     end
 
     def product_custom_list

--- a/app/controllers/concerns/search/product_filters.rb
+++ b/app/controllers/concerns/search/product_filters.rb
@@ -1,0 +1,54 @@
+module Search
+  module ProductFilters
+    def filters(products, filters)
+      { filters: accepted_filters(filters).each_with_object({}) {|f, h| h[f.pluralize] = send(f, products) } }
+    end
+
+    private
+
+    def accepted_filters(filters)
+      accepted_filters = %w[brand item subitem section project_type room_type specification]
+      filters.select {|filter| accepted_filters.include? filter }
+    end
+
+    def project_type(products)
+      lookup_table_data(products, 'room_type')
+    end
+
+    def room_type(products)
+      lookup_table_data(products, 'room_type')
+    end
+
+    def brand(products)
+      brand_ids = products.pluck(:brand_id)
+      ::Brand.where(id: brand_ids).map {|brand| { id: brand.id, name: brand.name } }
+    end
+
+    def item(products)
+      relations(products, :items)
+    end
+
+    def subitem(products)
+      relations(products, :subitems)
+    end
+
+    def section(products)
+      relations(products, :sections)
+    end
+
+    def specification(products)
+      ProjectSpec::Specification.by_user(current_user).by_products(products)
+    end
+
+    def lookup_table_data(products, category)
+      types = products.pluck(category.to_sym).flatten.uniq
+      LookupTable.by_category(category).where(code: types.map(&:to_i)).map do |lookup_table|
+        { id: lookup_table.code, name: lookup_table.translation_spa }
+      end
+    end
+
+    def relations(products, relation)
+      products.map(&relation).flatten.uniq.map {|ele| { id: ele.id, name: ele.name } }
+    end
+  end
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -29,7 +29,7 @@ class Product < ApplicationRecord
   scope :by_room_type,    ->(types)    { where("room_type && ?", "{#{ types.is_a?(Array) ? types.join(',') : types }}") }
   scope :by_subitem,      ->(subitems) { joins(:subitems).where(subitems: { id: subitems }) }
   scope :by_brand,        ->(brands)   { joins(:brand).where(brands: { id: brands }) }
-  scope :by_client,       ->(clients)   { joins(:client).where(clients: { id: clients }) }
+  scope :by_client,       ->(clients)  { joins(:client).where(clients: { id: clients }) }
   scope :original,        ->           { where(original_product_id: nil) }
   scope :used_on_spec,    ->           { where.not(original_product_id: nil) }
   scope :system_owned,    ->           { joins(user: :roles).where(roles: { name: 'superadmin' }) }

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -29,6 +29,7 @@ class Product < ApplicationRecord
   scope :by_room_type,    ->(types)    { where("room_type && ?", "{#{ types.is_a?(Array) ? types.join(',') : types }}") }
   scope :by_subitem,      ->(subitems) { joins(:subitems).where(subitems: { id: subitems }) }
   scope :by_brand,        ->(brands)   { joins(:brand).where(brands: { id: brands }) }
+  scope :by_client,       ->(clients)   { joins(:client).where(clients: { id: clients }) }
   scope :original,        ->           { where(original_product_id: nil) }
   scope :used_on_spec,    ->           { where.not(original_product_id: nil) }
   scope :system_owned,    ->           { joins(user: :roles).where(roles: { name: 'superadmin' }) }

--- a/app/models/project_spec/specification.rb
+++ b/app/models/project_spec/specification.rb
@@ -5,7 +5,11 @@ module ProjectSpec
     belongs_to :project
     has_one :user, through: :project
     has_many :blocks, class_name: 'ProjectSpec::Block', foreign_key: :project_spec_id
-
+    scope :by_products, lambda {|products|
+      product_ids = Product.where(original_product_id: products).pluck(:id)
+      with_products.where(project_spec_blocks: { spec_item_id: product_ids, spec_item_type: 'Product' })
+    }
+    scope :by_user, ->(user) { joins(:user).where(users: { id: user }) }
     scope :with_products, -> { joins(:blocks).distinct }
 
     def create_text(params)

--- a/spec/controllers/api/products_controller_spec.rb
+++ b/spec/controllers/api/products_controller_spec.rb
@@ -28,6 +28,15 @@ describe Api::ProductsController, type: :controller do
     }
   }
 
+  before do
+    create(:lookup_table, category: 'project_type', code: 1, translation_spa: 'a')
+    create(:lookup_table, category: 'project_type', code: 2, translation_spa: 'b')
+    create(:lookup_table, category: 'room_type', code: 1, translation_spa: 'a')
+    create(:lookup_table, category: 'room_type', code: 2, translation_spa: 'b')
+    create(:lookup_table, category: 'work_type', code: 1, translation_spa: 'a')
+    create(:lookup_table, category: 'work_type', code: 2, translation_spa: 'b')
+  end
+
   describe '#index' do
     context 'with valid session' do
       before do
@@ -235,12 +244,6 @@ describe Api::ProductsController, type: :controller do
           create(:resource_file, owner: product, attached: @document3, order: 1)
           create(:resource_file, owner: product, attached: @document4, order: 3)
           create(:resource_file, owner: product, attached: @document5, order: 4)
-          create(:lookup_table, category: 'project_type', code: 1, translation_spa: 'a')
-          create(:lookup_table, category: 'project_type', code: 2, translation_spa: 'b')
-          create(:lookup_table, category: 'room_type', code: 1, translation_spa: 'a')
-          create(:lookup_table, category: 'room_type', code: 2, translation_spa: 'b')
-          create(:lookup_table, category: 'work_type', code: 1, translation_spa: 'a')
-          create(:lookup_table, category: 'work_type', code: 2, translation_spa: 'b')
           product.update!(project_type: ['1', '2'], room_type: ['1', '2'], work_type: ['1', '2'])
         end
 


### PR DESCRIPTION
Trello Card
https://trello.com/c/BHv6tgwl/60-fe-hito-1-le%C3%B3n-1-recargar-filtros-con-los-valores-devueltos-en-el-endpoint-de-productos

Now the endpoint products receives a new param:

```
filter[]
```
possible values: 
```
filter[] = 'brand'
filter[] = 'section'
filter[] = 'item'
filter[] = 'project_type'
filter[] = 'room_type'
filter[] = 'specification'
```

And returns a new key with the filters specified on the request:
For example `/products?filters[]=brand`
```
filters: {
  brands: [
    {id: 1, 'marca 1'}
  ]
}